### PR TITLE
Unix Time Converter機能の追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,10 @@
 # CLAUDE.md for sdev
 
+## Workflow Guidelines
+- Create a new branch before implementing new features: `git checkout -b feature/<feature-name>`
+- Use descriptive branch names that reflect the feature or fix
+- Commit changes with clear, concise messages
+
 ## Build Commands
 - Build: `swift build`
 - Release build: `swift build -c release`
@@ -27,6 +32,11 @@
 ---
 
 # CLAUDE.md（日本語訳）
+
+## ワークフローガイドライン
+- 新機能を実装する前に新しいブランチを作成: `git checkout -b feature/<機能名>`
+- 機能や修正内容を反映した説明的なブランチ名を使用
+- 明確で簡潔なメッセージでコミット
 
 ## ビルドコマンド
 - ビルド: `swift build`

--- a/Sources/sdev/Commands/UnixTime.swift
+++ b/Sources/sdev/Commands/UnixTime.swift
@@ -1,0 +1,54 @@
+import ArgumentParser
+import Foundation
+
+struct UnixTime: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "unixtime",
+        abstract: "Convert between Unix timestamp and human-readable date"
+    )
+    
+    enum ConversionMode: String, ExpressibleByArgument {
+        case toDate = "to-date"
+        case fromDate = "from-date"
+    }
+    
+    @Argument(help: "Conversion mode: to-date (unix timestamp to date) or from-date (date to unix timestamp)")
+    var mode: ConversionMode
+    
+    @Argument(help: "Value to convert: unix timestamp (for to-date) or date string (for from-date)")
+    var value: String
+    
+    @Option(name: .shortAndLong, help: "Date format (default: yyyy-MM-dd HH:mm:ss)")
+    var format: String = "yyyy-MM-dd HH:mm:ss"
+    
+    func run() throws {
+        switch mode {
+        case .toDate:
+            // Convert Unix timestamp to date
+            guard let timestamp = TimeInterval(value) else {
+                throw ValidationError("Invalid Unix timestamp: \(value)")
+            }
+            
+            let date = Date(timeIntervalSince1970: timestamp)
+            let formatter = DateFormatter()
+            formatter.dateFormat = format
+            formatter.timeZone = TimeZone(abbreviation: "UTC")
+            let dateString = formatter.string(from: date)
+            
+            print("\(value) → \(dateString)")
+            
+        case .fromDate:
+            // Convert date to Unix timestamp
+            let formatter = DateFormatter()
+            formatter.dateFormat = format
+            formatter.timeZone = TimeZone(abbreviation: "UTC")
+            
+            guard let date = formatter.date(from: value) else {
+                throw ValidationError("Invalid date: \(value). Expected format: \(format)")
+            }
+            
+            let timestamp = date.timeIntervalSince1970
+            print("\(value) → \(Int(timestamp))")
+        }
+    }
+}

--- a/Sources/sdev/main.swift
+++ b/Sources/sdev/main.swift
@@ -11,7 +11,8 @@ struct SdevCommand: ParsableCommand {
         abstract: "A developer utility tool",
         subcommands: [
             Greeting.self,
-            FileDiff.self
+            FileDiff.self,
+            UnixTime.self
         ],
         defaultSubcommand: Greeting.self
     )

--- a/Tests/sdevTests/UnixTimeTests.swift
+++ b/Tests/sdevTests/UnixTimeTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+import class Foundation.Bundle
+import Foundation
+
+final class UnixTimeTests: XCTestCase {
+    func testUnixTimeToDate() throws {
+        let process = try runSdev(arguments: ["unixtime", "to-date", "1609459200"])
+        XCTAssertEqual(process.terminationStatus, 0)
+        
+        let output = try getOutput(from: process)
+        XCTAssertTrue(output.contains("1609459200 → 2021-01-01 00:00:00"), "Expected timestamp 1609459200 to convert to 2021-01-01 00:00:00")
+    }
+    
+    func testUnixTimeFromDate() throws {
+        let process = try runSdev(arguments: ["unixtime", "from-date", "2021-01-01 00:00:00"])
+        XCTAssertEqual(process.terminationStatus, 0)
+        
+        let output = try getOutput(from: process)
+        XCTAssertTrue(output.contains("2021-01-01 00:00:00 → 1609459200"), "Expected date 2021-01-01 00:00:00 to convert to timestamp 1609459200")
+    }
+    
+    func testUnixTimeWithCustomFormat() throws {
+        let process = try runSdev(arguments: ["unixtime", "to-date", "1609459200", "--format", "yyyy/MM/dd"])
+        XCTAssertEqual(process.terminationStatus, 0)
+        
+        let output = try getOutput(from: process)
+        XCTAssertTrue(output.contains("1609459200 → 2021/01/01"), "Expected timestamp 1609459200 to convert to 2021/01/01")
+    }
+    
+    // Helper method to run the executable
+    private func runSdev(arguments: [String] = []) throws -> Process {
+        // Find the executable path
+        let sdevBinary = productsDirectory.appendingPathComponent("sdev")
+        
+        let process = Process()
+        process.executableURL = sdevBinary
+        process.arguments = arguments
+        
+        let outputPipe = Pipe()
+        process.standardOutput = outputPipe
+        
+        try process.run()
+        process.waitUntilExit()
+        
+        return process
+    }
+    
+    // Helper to get output from process
+    private func getOutput(from process: Process) throws -> String {
+        let outputPipe = process.standardOutput as! Pipe
+        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        return String(data: outputData, encoding: .utf8) ?? ""
+    }
+    
+    /// Returns path to the built products directory.
+    private var productsDirectory: URL {
+        #if os(macOS)
+        for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
+            return bundle.bundleURL.deletingLastPathComponent()
+        }
+        fatalError("couldn't find the products directory")
+        #else
+        return Bundle.main.bundleURL
+        #endif
+    }
+}


### PR DESCRIPTION
## 概要
- Unix時間と人間が読める日時形式の相互変換機能を追加
- 双方向の変換（UnixタイムスタンプからDateへ、DateからUnixタイムスタンプへ）に対応
- 日付フォーマットのカスタマイズをサポート

## 機能詳細
- 新しいサブコマンド `unixtime` を追加
- 変換モード:
  - `to-date`: Unixタイムスタンプから日付への変換
  - `from-date`: 日付からUnixタイムスタンプへの変換
- オプション:
  - `--format, -f`: 日付のフォーマットを指定（デフォルト: yyyy-MM-dd HH:mm:ss）

## 使用例
```
# Unix timestampを日付に変換
sdev unixtime to-date 1609459200
# 出力: 1609459200 → 2021-01-01 00:00:00

# 日付をUnix timestampに変換
sdev unixtime from-date "2021-01-01 00:00:00"
# 出力: 2021-01-01 00:00:00 → 1609459200

# カスタムフォーマットを使用
sdev unixtime to-date 1609459200 --format "yyyy/MM/dd"
# 出力: 1609459200 → 2021/01/01
```

## テスト
- 単体テストを追加し、すべての主要機能をカバー
- すべてのテストが正常に通過することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)